### PR TITLE
Calculate size of buffer

### DIFF
--- a/examples/Downlink/Downlink.ino
+++ b/examples/Downlink/Downlink.ino
@@ -33,7 +33,7 @@ void loop() {
   // Send a byte
   byte buf[1];
   buf[0] = 20;
-  int downlinkBytes = ttn.sendBytes(buf, 1);
+  int downlinkBytes = ttn.sendBytes(buf);
 
   if (downlinkBytes > 0) {
     debugPrintLn("Received " + String(downlinkBytes) + " bytes")

--- a/examples/SendABP/SendABP.ino
+++ b/examples/SendABP/SendABP.ino
@@ -31,7 +31,7 @@ void setup() {
 
 void loop() {
   byte payload[] = { 0x48, 0x65, 0x6C, 0x6C, 0x6F };
-  ttn.sendBytes(payload, sizeof(payload));
+  ttn.sendBytes(payload);
   
   delay(20000);
 }

--- a/examples/SendOTAA/SendOTAA.ino
+++ b/examples/SendOTAA/SendOTAA.ino
@@ -32,7 +32,7 @@ void setup() {
 
 void loop() {
   byte payload[] = { 0x48, 0x65, 0x6C, 0x6C, 0x6F };
-  ttn.sendBytes(payload, sizeof(payload));
+  ttn.sendBytes(payload);
   
   delay(20000);
 }

--- a/examples/SensorExamples/DHTSensor/DHTSensor.ino
+++ b/examples/SensorExamples/DHTSensor/DHTSensor.ino
@@ -61,7 +61,7 @@ void loop() {
   debugPrint("Humidity: ");
   debugPrintLn(humidity);
   //send data
-  ttn.sendBytes(data, sizeof(data));
+  ttn.sendBytes(data);
 
   delay(20000);
 }

--- a/examples/SensorExamples/LightSensor/LightSensor.ino
+++ b/examples/SensorExamples/LightSensor/LightSensor.ino
@@ -48,7 +48,7 @@ void loop() {
   debugPrint("Transmitting Light level: ");
   debugPrintLn(light);
   //send data
-  ttn.sendBytes(data, sizeof(data));
+  ttn.sendBytes(data);
 
   delay(20000);
 }

--- a/examples/Workshop/Workshop.ino
+++ b/examples/Workshop/Workshop.ino
@@ -48,7 +48,7 @@ void loop() {
   byte data[3] = { 0x01, 0x02, 0x03 };
 
   // Send it to the network
-  ttn.sendBytes(data, sizeof(data));
+  ttn.sendBytes(data);
 
   // Wait 10 seconds
   delay(10000);

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -201,6 +201,15 @@ bool TheThingsNetwork::enableFsbChannels(int fsb) {
   return true;
 }
 
+int TheThingsNetwork::sizeofBuffer(const byte* buffer){
+  int i = 0;
+  while (*buffer) {
+    *buffer++;
+    i++;
+  }
+  return i;
+}
+
 bool TheThingsNetwork::personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]) {
   sendCommand(F("mac set devaddr"), devAddr, 4);
   sendCommand(F("mac set nwkskey"), nwkSKey, 16);
@@ -244,7 +253,9 @@ bool TheThingsNetwork::join(const byte appEui[8], const byte appKey[16]) {
   return true;
 }
 
-int TheThingsNetwork::sendBytes(const byte* buffer, int length, int port, bool confirm) {
+int TheThingsNetwork::sendBytes(const byte* buffer, int port, bool confirm) {
+  int length = sizeofBuffer(buffer);
+  debugPrintLn(String(length));
   String str = "";
   str.concat(F("mac tx "));
   str.concat(confirm ? F("cnf ") : F("uncnf "));
@@ -285,7 +296,7 @@ int TheThingsNetwork::sendString(String message, int port, bool confirm) {
   byte buf[l + 1];
   message.getBytes(buf, l + 1);
 
-  return sendBytes(buf, l, port, confirm);
+  return sendBytes(buf, port, confirm);
 }
 
 void TheThingsNetwork::showStatus() {

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -37,6 +37,7 @@ class TheThingsNetwork
     bool sendCommand(String cmd, String value, int waitTime = DEFAULT_WAIT_TIME);
     bool sendCommand(String cmd, const byte* buf, int length, int waitTime = DEFAULT_WAIT_TIME);
     bool enableFsbChannels(int fsb);
+    int sizeofBuffer(const byte* buffer);
 
   public:
     int downlinkPort;
@@ -45,7 +46,7 @@ class TheThingsNetwork
     void reset(bool adr = true, int sf = DEFAULT_SF, int fsb = DEFAULT_FSB);
     bool personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]);
     bool join(const byte appEui[8], const byte appKey[16]);
-    int sendBytes(const byte* buffer, int length, int port = 1, bool confirm = false);
+    int sendBytes(const byte* buffer, int port = 1, bool confirm = false);
     int sendString(String message, int port = 1, bool confirm = false);
     void showStatus();
 };


### PR DESCRIPTION
No longer requires you to pass length, closes #14

Tested by calling:

```c
  byte payload[] = { 0x48, 0x65, 0x6C, 0x6C, 0x6F };
  ttn.sendBytes(payload);
```

Length was correctly calculated as `5`.